### PR TITLE
Feat/files in gh org

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,12 @@
+certifi==2022.9.24
+charset-normalizer==2.1.1
 click==8.1.3
 colorama==0.4.6
 commonmark==0.9.1
+idna==3.4
 Pygments==2.13.0
+requests==2.28.1
 rich==12.6.0
 shellingham==1.5.0
 typer==0.6.1
+urllib3==1.26.13

--- a/scan-repo.py
+++ b/scan-repo.py
@@ -16,9 +16,10 @@ def get_repos_given_org(git_org, ghtoken):
     """
     Uses GH API to get list of repos for get_manifest_from_clone
     """
-    getreposurl = 'https://api.github.com/orgs/'+{git_org}+'/repos'
+    baseghurl = 'https://api.github.com/orgs/'
+    getreposurl = ''.join([baseghurl,str(git_org),'/repos'])
     getreposheader = {'Authorization': 'token' + ghtoken }
-    ghrepos = requests.get(getreposurl, headers=getreposheader)
+    ghrepos = requests.get(getreposurl, headers=getreposheader).json()
     return ghrepos
   
 
@@ -110,22 +111,46 @@ def get_manifest_from_clone(repo_name, origin):
     return manifest_count_dict
 
 
-def main(giturl: str = typer.Option("--gitrepo", help = "If getting manifest files for a repo, enter the git url with this option"), gitorg: str = typer.Option("--gitorg", help="If getting manifest files for repos within a GitHub org, enter the name of your GitHub Organization with this option."), ghtoken: str = typer.Argument (None, envvar="GITHUB_TOKEN", help="Github Personal Access Token, required if getting manifest files withing a GitHub Org. Accepts GITHUB_TOKEN as an environmental variable.")):
-    # if --gitorg isn't entered, is gitorg undefined or is it ""
-    # Also, is this necessary? Unsure if this is suficcient or will create issues later on w/ none or both inputs
-    # gh -- optional argument with none as default variable? Optional isn't working so unsure. Also unsure how to document the env variable required--token.
+def main(
+    giturl: str = typer.Option(None, "--gitrepo", help = "If getting manifest files for a repo, enter the git url with this option"), 
+    gitorg: str = typer.Option(None, "--gitorg", help="If getting manifest files for repos within a GitHub org, enter the name of your GitHub Organization with this option."), 
+    outputfile: str = typer.Argument("manifestcount.json", help="The name of the json file to output manifest file counts in the root directory."),
+    ghtoken: str = typer.Argument (None, envvar="GITHUB_TOKEN", help="Github Personal Access Token, required if getting manifest files withing a GitHub Org.",show_default=False)):
+    jsonoutputfile = open(outputfile, "w")
+    jsonoutputfile.close()
     if giturl:
         print(f"hi {giturl}")
         manifest_count = get_manifest_from_clone(giturl, "master")
-        serialize_manifest = json.dumps(manifest_count)
+        # Not JSON. The objects aren't between brackets.
+        manifest_count_with_repo = {
+                "repo_url": giturl,
+                "manifest_files": manifest_count
+            }
+        serialize_manifest = json.dumps(manifest_count_with_repo,indent=4)
         print (serialize_manifest)
+        with open(outputfile,"a") as jsonoutputfile:
+            jsonoutputfile.write(serialize_manifest)
+            jsonoutputfile.close()
     if gitorg:
         ghrepos = get_repos_given_org(gitorg,ghtoken)
+        # jsonoutputfile = open(outputfile,"w")
         for ghrepo in ghrepos:
-            ghrepourl = ghrepo['owner']['url']
-            manifest_count = get_manifest_from_clone(ghrepourl, "master")
-            serialize_manifest = json.dumps(manifest_count)
-            print(f"hi {ghrepourl}")
+            giturl = ghrepo['html_url']
+            defaultbranch = ghrepo['default_branch']
+            manifest_count = get_manifest_from_clone(giturl, defaultbranch)
+            # this kind of works, but like in line 127-132 not JSON. The objects aren't between brackets and aren't separated by commas.
+            # ToDo: Find a better way to accomplish or alternative format
+            manifest_count_with_repo = {
+                "full_repo_name": ghrepo['full_name'],
+                "manifest_files": manifest_count
+            }
+            serialize_manifest = json.dumps(manifest_count_with_repo,indent=4,)
+            print(serialize_manifest)
+            with open (outputfile,"a") as jsonoutputfile:
+                jsonoutputfile.write(serialize_manifest)
+                jsonoutputfile.close()
+            
+
 
 
 

--- a/scan-repo.py
+++ b/scan-repo.py
@@ -4,12 +4,26 @@ import subprocess
 import re
 import json
 import typer
+import requests
 
 MANIFEST_PATTERN_SCA = '^(?![.]).*(package[.]json|Gemfile[.]lock|pom[.]xml|build[.]gradle|.*[.]lockfile|build[.]sbt|.*req.*[.]txt|Gopkg[.]lock|go[.]mod|vendor[.]json|packages[.]config|.*[.]csproj|.*[.]fsproj|.*[.]vbproj|project[.]json|project[.]assets[.]json|composer[.]lock|Podfile|Podfile[.]lock)$'
 manifest_count_dict = {
     "package.json": 0,
     "pom.xml": 0
 }
+
+def get_repos_given_org(git_org, ghtoken):
+    """
+    Uses GH API to get list of repos for get_manifest_from_clone
+    """
+    getreposurl = 'https://api.github.com/orgs/'+{git_org}+'/repos'
+    getreposheader = {'Authorization': 'token' + ghtoken }
+    ghrepos = requests.get(getreposurl, headers=getreposheader)
+    return ghrepos
+  
+
+
+
 
 def get_manifest_from_clone(repo_name, origin):
     """
@@ -96,11 +110,23 @@ def get_manifest_from_clone(repo_name, origin):
     return manifest_count_dict
 
 
-def main(giturl: str = typer.Option(..., "--gitrepo")):
-    print(f"hi {giturl}")
-    manifest_count = get_manifest_from_clone(giturl, "master")
-    serialize_manifest = json.dumps(manifest_count)
-    print (serialize_manifest)
+def main(giturl: str = typer.Option("--gitrepo", help = "If getting manifest files for a repo, enter the git url with this option"), gitorg: str = typer.Option("--gitorg", help="If getting manifest files for repos within a GitHub org, enter the name of your GitHub Organization with this option."), ghtoken: str = typer.Argument (None, envvar="GITHUB_TOKEN", help="Github Personal Access Token, required if getting manifest files withing a GitHub Org. Accepts GITHUB_TOKEN as an environmental variable.")):
+    # if --gitorg isn't entered, is gitorg undefined or is it ""
+    # Also, is this necessary? Unsure if this is suficcient or will create issues later on w/ none or both inputs
+    # gh -- optional argument with none as default variable? Optional isn't working so unsure. Also unsure how to document the env variable required--token.
+    if giturl:
+        print(f"hi {giturl}")
+        manifest_count = get_manifest_from_clone(giturl, "master")
+        serialize_manifest = json.dumps(manifest_count)
+        print (serialize_manifest)
+    if gitorg:
+        ghrepos = get_repos_given_org(gitorg,ghtoken)
+        for ghrepo in ghrepos:
+            ghrepourl = ghrepo['owner']['url']
+            manifest_count = get_manifest_from_clone(ghrepourl, "master")
+            serialize_manifest = json.dumps(manifest_count)
+            print(f"hi {ghrepourl}")
+
 
 
 if __name__ == "__main__":

--- a/scan-repo.py
+++ b/scan-repo.py
@@ -118,10 +118,10 @@ def main(
     ghtoken: str = typer.Argument (None, envvar="GITHUB_TOKEN", help="Github Personal Access Token, required if getting manifest files withing a GitHub Org.",show_default=False)):
     jsonoutputfile = open(outputfile, "w")
     jsonoutputfile.close()
+    
     if giturl:
-        print(f"hi {giturl}")
+        # print(f"hi {giturl}")
         manifest_count = get_manifest_from_clone(giturl, "master")
-        # Not JSON. The objects aren't between brackets.
         manifest_count_with_repo = {
                 "repo_url": giturl,
                 "manifest_files": manifest_count
@@ -133,22 +133,21 @@ def main(
             jsonoutputfile.close()
     if gitorg:
         ghrepos = get_repos_given_org(gitorg,ghtoken)
-        # jsonoutputfile = open(outputfile,"w")
+        dict_of_repos = []
         for ghrepo in ghrepos:
             giturl = ghrepo['html_url']
             defaultbranch = ghrepo['default_branch']
             manifest_count = get_manifest_from_clone(giturl, defaultbranch)
-            # this kind of works, but like in line 127-132 not JSON. The objects aren't between brackets and aren't separated by commas.
-            # ToDo: Find a better way to accomplish or alternative format
             manifest_count_with_repo = {
                 "full_repo_name": ghrepo['full_name'],
                 "manifest_files": manifest_count
             }
-            serialize_manifest = json.dumps(manifest_count_with_repo,indent=4,)
-            print(serialize_manifest)
-            with open (outputfile,"a") as jsonoutputfile:
-                jsonoutputfile.write(serialize_manifest)
-                jsonoutputfile.close()
+            dict_of_repos.append(manifest_count_with_repo)
+        serialize_manifest = json.dumps(dict_of_repos,indent=4)
+        print(serialize_manifest)
+        with open (outputfile,"a") as jsonoutputfile:
+            jsonoutputfile.write(serialize_manifest)
+            jsonoutputfile.close()
             
 
 


### PR DESCRIPTION
Added a feature to count manifest files given a GitHub Organization.
Additionally:
Changes to the manifest file count dictionary
Additional parameter for default branch when counting for an individual repo
